### PR TITLE
Fixes #2, #4 and #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .*
 !/.gitignore
 /Universal-Space-Operations-Center/nbproject/
+/Universal-Space-Operations-Center/*.iml

--- a/Universal-Space-Operations-Center/pom.xml
+++ b/Universal-Space-Operations-Center/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>com.github.pcmehlitz</groupId>
             <artifactId>worldwind-pcm</artifactId>
-            <version>2.1.0.185</version>
+            <version>2.1.0.187</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/GroundSegment.java
+++ b/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/GroundSegment.java
@@ -77,6 +77,8 @@ public class GroundSegment extends Application {
     @Override
     public void stop() throws Exception{
         super.stop();
+        //TODO temp fix for worldwind panels not closing on app stop
+        //TODO system.exit force closes all threads, but it is non optimal
         System.exit(0);
     }
 }

--- a/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/GroundSegment.java
+++ b/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/GroundSegment.java
@@ -42,8 +42,8 @@ import javafx.stage.Stage;
 public class GroundSegment extends Application {
 
     /**
-     * @param stage
-     * @param args the command line arguments
+     * Starts Application
+     * @param stage main stage
      */
     @Override
     public void start(Stage stage) {
@@ -52,6 +52,9 @@ public class GroundSegment extends Application {
         MainController.getInstance().setStage(stage);
 
         stage.setScene(GuiBuilder.createGUIFromConfig());
+        stage.setMinWidth(700);
+        stage.setWidth(900);
+        stage.setMinHeight(500);
         stage.show();
     }
 
@@ -61,7 +64,7 @@ public class GroundSegment extends Application {
     public static void main(String[] args) {
         launch(args);
         
-        //close serial communiction if it is open on window close
+        //close serial communication if it is open on window close
         if(SerialComm.getInstance().isOpen()){
             SerialComm.getInstance().close();
         }

--- a/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/GroundSegment.java
+++ b/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/GroundSegment.java
@@ -69,4 +69,13 @@ public class GroundSegment extends Application {
             SerialComm.getInstance().close();
         }
     }
+
+    // Closes all threads on Apllication close
+    // May not be the best solution in the long run,
+    // since this force closes all active threads
+    @Override
+    public void stop() throws Exception{
+        super.stop();
+        System.exit(0);
+    }
 }

--- a/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/GroundSegment.java
+++ b/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/GroundSegment.java
@@ -26,6 +26,7 @@ package com.ksatstuttgart.usoc;
 import com.ksatstuttgart.usoc.controller.MainController;
 import com.ksatstuttgart.usoc.controller.communication.SerialComm;
 import com.ksatstuttgart.usoc.gui.setup.GuiBuilder;
+import com.ksatstuttgart.usoc.gui.worldwind.GNSSPanel;
 import javafx.application.Application;
 import javafx.stage.Stage;
 

--- a/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/controller/MainController.java
+++ b/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/controller/MainController.java
@@ -65,18 +65,29 @@ public class MainController {
     }
 
     public MainController() {
-        //TODO: remove this and somehow integrate this in the GUI or find better 
-        //place. This loads the xml structure for reading the messages received
-        //via the Iridium communication link
         listeners = new ArrayList<>();
 
-        SBD340 structure = XMLReader.getInstance()
-                .getMessageStructure("protocols/ROACH.xml");
+        // Loads defaultProtocol by default
+        // Can be changed on runtime in the UI
+        SBD340 structure =
+                loadProtocol("protocols/defaultProtocol.xml");
+
         messageController = new MessageController(structure);
 
         MailReceiver.getInstance().addMailUpdateListener(new MailListener());
         SerialComm.getInstance().addSerialListener(new RXListener());
     }
+
+    /**
+     * Loads a given protocol
+     * @param protocol
+     * @return
+     */
+    public SBD340 loadProtocol(String protocol) {
+        return XMLReader.getInstance()
+                .getMessageStructure(protocol);
+    }
+
 
     public void setStage(Stage stage) {
         this.stage = stage;

--- a/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/gui/setup/GuiBuilder.java
+++ b/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/gui/setup/GuiBuilder.java
@@ -114,7 +114,7 @@ public class GuiBuilder {
         MenuBar menuBar = new MenuBar();
 
         // Create File Menu
-        Menu fileMenu = new Menu("Edit");
+        Menu editMenu = new Menu("Edit");
 
         // Load Protocol Menu Item
         Menu loadProtocolSubMenu = new Menu("Protocol");
@@ -158,10 +158,10 @@ public class GuiBuilder {
         });
 
         // Adds all menu items to file menu
-        fileMenu.getItems().addAll(loadProtocolSubMenu, quitMenuItem);
+        editMenu.getItems().addAll(loadProtocolSubMenu, new SeparatorMenuItem(), quitMenuItem);
 
         // Adds all Menus to Menubar
-        menuBar.getMenus().addAll(fileMenu);
+        menuBar.getMenus().addAll(editMenu);
 
         return menuBar;
     }

--- a/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/gui/setup/GuiBuilder.java
+++ b/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/gui/setup/GuiBuilder.java
@@ -29,7 +29,6 @@ import com.ksatstuttgart.usoc.gui.controller.StatePanelController;
 import com.ksatstuttgart.usoc.gui.worldwind.GNSSPanel;
 
 import java.io.File;
-import java.net.URL;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
@@ -39,9 +38,24 @@ import javafx.event.EventHandler;
 import javafx.scene.Scene;
 import javafx.scene.chart.LineChart;
 import javafx.scene.chart.NumberAxis;
-import javafx.scene.control.*;
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Label;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.RadioMenuItem;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.SeparatorMenuItem;
+import javafx.scene.control.SplitPane;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
 import javafx.scene.control.TabPane.TabClosingPolicy;
-import javafx.scene.layout.*;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 
 /**
  * This class builds the GUI FXML structure based on input parameters in the properties file
@@ -60,7 +74,7 @@ public class GuiBuilder {
     /**
      * Creates the main scene that will be added
      * to the Stage
-     * @return
+     * @return Scene
      */
     public static Scene createGUIFromConfig() {
         // Loads the configuration file
@@ -109,6 +123,10 @@ public class GuiBuilder {
         return new Scene(mainBorder);
     }
 
+    /**
+     * Creates the menu bar for the main stage
+     * @return menu bar
+     */
     private static MenuBar createMenuBar() {
         // Main MenuBar
         MenuBar menuBar = new MenuBar();
@@ -124,7 +142,7 @@ public class GuiBuilder {
 
         // Below condition should never happen
         // By default, defaultProtocol is loaded
-        if (protocols.size() == 0) {
+        if (protocols.isEmpty()) {
             loadProtocolSubMenu.setDisable(true);
         } else {
             // Toggle Group ensures only one radio button is selected at a time
@@ -153,7 +171,7 @@ public class GuiBuilder {
         quitMenuItem.setOnAction(new EventHandler<ActionEvent>() {
             @Override
             public void handle(ActionEvent actionEvent) {
-                quitApplication();
+                MainController.getInstance().getStage().close();
             }
         });
 
@@ -167,6 +185,11 @@ public class GuiBuilder {
     }
 
 
+    /**
+     * Responsible for creating the State Panel
+     * @param config configuration properties
+     * @return ScrollPane
+     */
     private static ScrollPane createStatePanel(Properties config) {
         ScrollPane stateScroll = new ScrollPane();
         StatePanelController statePanelController = new StatePanelController();
@@ -295,19 +318,6 @@ public class GuiBuilder {
 
         logTab.minWidth(200);
         return logTab;
-    }
-
-    private static void quitApplication() {
-        Alert quitConfirmation = new Alert(Alert.AlertType.WARNING,
-                "Are you sure you want to quit?", ButtonType.YES, ButtonType.CANCEL);
-
-        quitConfirmation.setTitle("Exit Application?");
-        quitConfirmation.setHeaderText("Please Confirm.");
-        quitConfirmation.showAndWait();
-
-        if (quitConfirmation.getResult() == ButtonType.YES) {
-            MainController.getInstance().getStage().close();
-        }
     }
 
     private static List<String> getAvailableProtocols() {

--- a/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/gui/worldwind/GNSSPanel.java
+++ b/Universal-Space-Operations-Center/src/main/java/com/ksatstuttgart/usoc/gui/worldwind/GNSSPanel.java
@@ -23,6 +23,7 @@
  */
 package com.ksatstuttgart.usoc.gui.worldwind;
 
+import com.ksatstuttgart.usoc.controller.MainController;
 import com.ksatstuttgart.usoc.controller.MessageController;
 import com.ksatstuttgart.usoc.data.ErrorEvent;
 import com.ksatstuttgart.usoc.data.SerialEvent;
@@ -500,5 +501,11 @@ public class GNSSPanel extends DataPanel {
         }
 
         return center.distanceTo3(center.add3(f.multiply3(-maxDistance)));
+    }
+
+    public void closePanels() {
+        wwp_big.shutdown();
+        wwp_sideView.shutdown();
+        wwp_topView.shutdown();
     }
 }

--- a/Universal-Space-Operations-Center/src/main/resources/config/config.properties
+++ b/Universal-Space-Operations-Center/src/main/resources/config/config.properties
@@ -39,7 +39,7 @@ statePanel          =   true
 # GNSS 3D View
 # Mandatory: YES
 # Expected input: boolean (true, false)
-GNSS3dView          =   false
+GNSS3dView          =   true
 
 # Name of experiment the ground station is used for
 # Mandatory: YES
@@ -99,8 +99,8 @@ iridiumPanel        =   true
 # with i = {1,2,3,...} as number of segments
 #
 # Mandatory: YES
-segmentTitle[1]         =   Titel 1
-segmentTitle[2]         =   Titel 2
+segmentTitle[1]         =   Title 1
+segmentTitle[2]         =   Title 2
 #
 # Configurtion of the labels
 keyword[1][1]           =   11


### PR DESCRIPTION
- Tabbed Panes (Charts and GNSS), State Panel and Log Panel are now inside SplitPanes. The user can now resize each panel accordingly

- Main Stage now sets it's title according to the experiment name defined in the configuration file

- Partially fixes issue #3 . Charts are always visible, except when the user resizes the split panes. Some values still need to be tweaked.

- The createGUI method has been splitted into various methods to allow better organization and modularity

- All threads are now closed on Application shutdown. (May not be the best solution)

- Adds a MenuBar with an option to load protocols on run time. 

Any feedback is welcome. If you want me to change something, let me know.